### PR TITLE
use `#[panic_handler]` instead of `#[panic_implementation]`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly
@@ -45,6 +44,9 @@ install:
 
 script:
   - bash ci/script.sh
+
+after_success:
+  - bash ci/after-success.sh
 
 after_script: set +e
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.3.1] - 2018-09-03
+## [v0.4.0] - 2018-09-03
 
 ### Changed
 
 - This crate no longer depends on `arm-none-eabi-gcc`.
 
-- Move from the `panic_implementation` attribute to the `panic_handler`
-  attribute, which will be stabilized.
+- [breaking-change] Move from the `panic_implementation` attribute to the
+  `panic_handler` attribute, which will be stabilized.
 
 ## [v0.3.0] - 2018-06-04
 
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.3.1...HEAD
-[v0.3.1]: https://github.com/rust-embedded/panic-semihosting/compare/v0.3.0...v0.3.1
+[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.1] - 2018-09-03
+
+### Changed
+
+- This crate no longer depends on `arm-none-eabi-gcc`.
+
+- Move from the `panic_implementation` attribute to the `panic_handler`
+  attribute, which will be stabilized.
+
 ## [v0.3.0] - 2018-06-04
 
 ### Changed
@@ -26,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/panic-semihosting/compare/v0.3.0...HEAD
-[v0.3.0]: https://github.com/japaric/panic-semihosting/compare/v0.2.0...v0.3.0
-[v0.2.0]: https://github.com/japaric/panic-semihosting/compare/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.3.1...HEAD
+[v0.3.1]: https://github.com/rust-embedded/panic-semihosting/compare/v0.3.0...v0.3.1
+[v0.3.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,16 @@
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["no-std"]
 description = "Report panic messages to the host stderr using semihosting"
+documentation = "https://rust-embedded.github.io/panic-semihosting/panic_semihosting"
 keywords = ["panic-impl", "panic", "semihosting"]
 license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
-repository = "https://github.com/japaric/panic-semihosting"
-version = "0.3.0"
+repository = "https://github.com/rust-embedded/panic-semihosting"
+version = "0.3.1"
 
 [dependencies]
-cortex-m = "0.5.0"
-cortex-m-semihosting= "0.3.0"
+cortex-m = "0.5.6"
+cortex-m-semihosting= "0.3.1"
 
 [features]
 inline-asm = ["cortex-m-semihosting/inline-asm", "cortex-m/inline-asm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["panic-impl", "panic", "semihosting"]
 license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
 repository = "https://github.com/rust-embedded/panic-semihosting"
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies]
 cortex-m = "0.5.6"

--- a/ci/after-success.sh
+++ b/ci/after-success.sh
@@ -1,0 +1,20 @@
+set -euxo pipefail
+
+main() {
+    cargo doc
+
+    mkdir ghp-import
+
+    curl -Ls https://github.com/davisp/ghp-import/archive/master.tar.gz |
+        tar --strip-components 1 -C ghp-import -xz
+
+    ./ghp-import/ghp_import.py target/doc
+
+    set +x
+    git push -fq https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG.git gh-pages && echo OK
+}
+
+# only publish on successful merges to master
+if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ] && [ $TARGET = x86_64-unknown-linux-gnu ]; then
+    main
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,6 @@
 //!
 //! [`cortex-m-semihosting`]: https://crates.io/crates/cortex-m-semihosting
 //!
-//! # Requirements
-//!
-//! To build this crate on the stable or beta channels `arm-none-eabi-gcc` needs to be installed and
-//! available in `$PATH`.
-//!
 //! # Usage
 //!
 //! ``` ignore
@@ -50,13 +45,10 @@
 //!
 //! When this feature is disabled semihosting is implemented using FFI calls into an external
 //! assembly file and compiling this crate works on stable and beta.
-//!
-//! Apart from the toolchain requirement, enabling `inline-asm` removes the requirement of having
-//! `arm-none-eabi-gcc` installed on the host.
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(panic_implementation)]
+#![feature(panic_handler)]
 #![no_std]
 
 extern crate cortex_m;
@@ -68,7 +60,7 @@ use core::panic::PanicInfo;
 use cortex_m::{asm, interrupt};
 use sh::hio;
 
-#[panic_implementation]
+#[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     interrupt::disable();
 


### PR DESCRIPTION
the later has been deprecated.

`panic_implementation` was deprecated in today's nightly but existing builds
won't break (they'll just get an extra warning).

Do not merge this just yet because that will break builds that haven't move to
the latest nightly. We should merge this in one week or so to not break people
that don't often update their nightly compiler.

This PR also puts our docs on GH pages because docs.rs won't be able to build
the docs after this change.

cc @rust-embedded/cortex-m