### PR TITLE
remove `panic_handler` feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.0] - 2018-09-10
+
+- [breaking-change] The `panic_handler` feature gate has been removed. This
+  crate will compile on 1.30-beta and on stable 1.30 when they are released.
+
 ## [v0.4.0] - 2018-09-03
 
 ### Changed
@@ -35,7 +40,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.0...HEAD
+[v0.5.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["no-std"]
 description = "Report panic messages to the host stderr using semihosting"
 documentation = "https://rust-embedded.github.io/panic-semihosting/panic_semihosting"
-keywords = ["panic-impl", "panic", "semihosting"]
+keywords = ["panic-handler", "panic-impl", "panic", "semihosting"]
 license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
 repository = "https://github.com/rust-embedded/panic-semihosting"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 cortex-m = "0.5.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(panic_handler)]
 #![no_std]
 
 extern crate cortex_m;


### PR DESCRIPTION
This crate will compile on 1.30-beta and on stable 1.30 when they are released.

r? @rust-embedded/cortex-m (anyone)