### PR TITLE
add "exit" Cargo feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.1] - 2018-10-27
+
+### Added
+
+- An opt-in "exit" Cargo feature to have the panic handler perform an exit
+  semihosting call after logging the panic message.
+
 ## [v0.5.0] - 2018-09-10
 
 - [breaking-change] The `panic_handler` feature gate has been removed. This
@@ -40,7 +47,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.1...HEAD
+[v0.5.1]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/rust-embedded/panic-semihosting/compare/v0.2.0...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ keywords = ["panic-handler", "panic-impl", "panic", "semihosting"]
 license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
 repository = "https://github.com/rust-embedded/panic-semihosting"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 cortex-m = "0.5.6"
 cortex-m-semihosting= "0.3.1"
 
 [features]
+exit = []
 inline-asm = ["cortex-m-semihosting/inline-asm", "cortex-m/inline-asm"]


### PR DESCRIPTION
When this feature is enabled the panic handler performs an exit semihosting call
after logging the panic message. This is useful when emulating the program on
QEMU as it causes the QEMU process to exit with a non-zero exit code; thus it
can be used to implement Cortex-M tests that run on the host.

this also prepares the crate for a new release